### PR TITLE
fix: replace deprecated rust extension

### DIFF
--- a/vscode/user-setup.sh
+++ b/vscode/user-setup.sh
@@ -30,7 +30,7 @@ extensions=(
   "ms-vscode.cmake-tools" \
   "ms-vscode.cpptools" \
   "redhat.vscode-yaml" \
-  "rust-lang.rust" \
+  "rust-lang.rust-analyzer" \
   "twxs.cmake" \
   "vadimcn.vscode-lldb" \
   "bazelbuild.vscode-bazel" \


### PR DESCRIPTION
Replace deprecated Rust extension for VS Code.